### PR TITLE
Try to speed up the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ cache:
   directories:
     - $HOME/.cargo
 before_cache:
+  - cargo install cargo-tarpaulin
   - rm -rf $HOME/.cargo/registry
-  - cargo install cargo-tarpaulin -f
 script:
   - cargo clean
   - cargo build


### PR DESCRIPTION
If we install the tarpaulin dependency non-forcefully and *before* we
drop the registry subdirectory we should be both faster and have better
space efficiency.